### PR TITLE
go vet is embedded in Go after v1.6

### DIFF
--- a/testdata/Makefile
+++ b/testdata/Makefile
@@ -1,7 +1,7 @@
 FILES:=$(wildcard out/*.go)
 
 .PHONY: check
-check: errcheck vet golint $(FILES:.go=.checked)
+check: errcheck golint $(FILES:.go=.checked)
 
 out/%.checked: out/%.go
 	errcheck $<
@@ -29,9 +29,6 @@ out/nocompress-nomemcopy.go: $(wildcard in/**/*) $(GOPATH)/bin/go-bindata
 
 errcheck:
 	go get github.com/kisielk/errcheck
-
-vet:
-	go get golang.org/x/tools/cmd/vet
 
 golint:
 	go get github.com/golang/lint/golint


### PR DESCRIPTION
Issue: jteeuwen/go-bindata#152
Original PR: jteeuwen/go-bindata/pull/154

`go vet` tool has been moved to main repository since Go 1.5 [1], not Go v1.6.

[1] https://golang.org/doc/go1.5