### PR TITLE
Add '-include' regex patterns

### DIFF
--- a/config.go
+++ b/config.go
@@ -139,7 +139,8 @@ type Config struct {
 	// will match any .gitignore file.
 	//
 	// This parameter can be provided multiple times.
-	Ignore []*regexp.Regexp
+	Ignore  []*regexp.Regexp
+	Include []*regexp.Regexp
 
 	// MD5Checksum is a flag that, when set to true, indicates to calculate
 	// MD5 checksums for files.
@@ -155,6 +156,7 @@ func NewConfig() *Config {
 	c.Debug = false
 	c.Output = "./bindata.go"
 	c.Ignore = make([]*regexp.Regexp, 0)
+	c.Include = make([]*regexp.Regexp, 0)
 	return c
 }
 

--- a/convert_test.go
+++ b/convert_test.go
@@ -21,7 +21,7 @@ func TestFindFiles(t *testing.T) {
 	var visitedPaths = make(map[string]bool)
 	prefix := regexp.MustCompile("testdata/dupname")
 
-	err := findFiles("testdata/dupname", prefix, true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/dupname", prefix, true, &toc, []*regexp.Regexp{}, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
@@ -38,7 +38,7 @@ func TestFindFilesWithSymlinks(t *testing.T) {
 	var visitedPaths = make(map[string]bool)
 	prefix := regexp.MustCompile("testdata/symlinkSrc")
 
-	err := findFiles("testdata/symlinkSrc", prefix, true, &tocSrc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/symlinkSrc", prefix, true, &tocSrc, []*regexp.Regexp{}, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
@@ -47,7 +47,7 @@ func TestFindFilesWithSymlinks(t *testing.T) {
 	visitedPaths = make(map[string]bool)
 	prefix = regexp.MustCompile("testdata/symlinkParent")
 
-	err = findFiles("testdata/symlinkParent", prefix, true, &tocTarget, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err = findFiles("testdata/symlinkParent", prefix, true, &tocTarget, []*regexp.Regexp{}, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
@@ -72,7 +72,7 @@ func TestFindFilesWithRecursiveSymlinks(t *testing.T) {
 	var visitedPaths = make(map[string]bool)
 	prefix := regexp.MustCompile("testdata/symlinkRecursiveParent")
 
-	err := findFiles("testdata/symlinkRecursiveParent", prefix, true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/symlinkRecursiveParent", prefix, true, &toc, []*regexp.Regexp{}, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}
@@ -89,7 +89,7 @@ func TestFindFilesWithSymlinkedFile(t *testing.T) {
 	var visitedPaths = make(map[string]bool)
 	prefix := regexp.MustCompile("testdata/symlinkFile")
 
-	err := findFiles("testdata/symlinkFile", prefix, true, &toc, []*regexp.Regexp{}, knownFuncs, visitedPaths)
+	err := findFiles("testdata/symlinkFile", prefix, true, &toc, []*regexp.Regexp{}, []*regexp.Regexp{}, knownFuncs, visitedPaths)
 	if err != nil {
 		t.Errorf("expected to be no error: %+v", err)
 	}

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -39,14 +39,16 @@ var (
 
 // List of error messages.
 var (
-	ErrInvalidIgnoreRegex = errors.New("Invalid -ignore regex pattern")
-	ErrInvalidPrefixRegex = errors.New("Invalid -prefix regex pattern")
-	ErrNoInput            = errors.New("Missing <input directories>")
+	ErrInvalidIgnoreRegex  = errors.New("Invalid -ignore regex pattern")
+	ErrInvalidIncludeRegex = errors.New("Invalid -include regex pattern")
+	ErrInvalidPrefixRegex  = errors.New("Invalid -prefix regex pattern")
+	ErrNoInput             = errors.New("Missing <input directories>")
 )
 
 // List of local variables.
 var (
 	argIgnore  []string
+	argInclude []string
 	argVersion bool
 	argPrefix  string
 	cfg        *bindata.Config
@@ -114,6 +116,7 @@ func initArgs() {
 	flag.StringVar(&cfg.Tags, "tags", cfg.Tags, "Optional set of build tags to include.")
 	flag.UintVar(&cfg.Mode, "mode", cfg.Mode, "Optional file mode override for all files.")
 	flag.Var((*AppendSliceValue)(&argIgnore), "ignore", "Regex pattern to ignore")
+	flag.Var((*AppendSliceValue)(&argInclude), "include", "Regex pattern to include")
 }
 
 //
@@ -147,6 +150,11 @@ func parseArgs() (err error) {
 	}
 
 	err = parseIgnore()
+	if err != nil {
+		return
+	}
+
+	err = parseInclude()
 	if err != nil {
 		return
 	}
@@ -185,6 +193,21 @@ func parseIgnore() (err error) {
 		}
 
 		cfg.Ignore = append(cfg.Ignore, ignoreVal)
+	}
+
+	return
+}
+
+func parseInclude() (err error) {
+	var includeVal *regexp.Regexp
+
+	for _, pattern := range argInclude {
+		includeVal, err = regexp.Compile(pattern)
+		if err != nil {
+			return ErrInvalidIncludeRegex
+		}
+
+		cfg.Include = append(cfg.Include, includeVal)
 	}
 
 	return

--- a/go-bindata/main_test.go
+++ b/go-bindata/main_test.go
@@ -93,7 +93,8 @@ func TestParseArgs(t *testing.T) {
 			Input: []bindata.InputConfig{{
 				Path: argInputPath,
 			}},
-			Ignore: defConfig.Ignore,
+			Ignore:  defConfig.Ignore,
+			Include: defConfig.Include,
 		},
 	}, {
 		desc: `With "-pkg ` + argPkg + `"`,
@@ -108,7 +109,8 @@ func TestParseArgs(t *testing.T) {
 			Input: []bindata.InputConfig{{
 				Path: argInputPath,
 			}},
-			Ignore: defConfig.Ignore,
+			Ignore:  defConfig.Ignore,
+			Include: defConfig.Include,
 		},
 	}, {
 		desc: `With "-o ` + argOutFile + `" (package name should be "` + argOutPkg + `")`,
@@ -123,7 +125,8 @@ func TestParseArgs(t *testing.T) {
 			Input: []bindata.InputConfig{{
 				Path: argInputPath,
 			}},
-			Ignore: defConfig.Ignore,
+			Ignore:  defConfig.Ignore,
+			Include: defConfig.Include,
 		},
 	}, {
 
@@ -140,7 +143,8 @@ func TestParseArgs(t *testing.T) {
 			Input: []bindata.InputConfig{{
 				Path: argInputPath,
 			}},
-			Ignore: defConfig.Ignore,
+			Ignore:  defConfig.Ignore,
+			Include: defConfig.Include,
 		},
 	}}
 


### PR DESCRIPTION
Support -include <regex> which is similar to -ignore with the opposite meaning.
-include overrides the matching decisions made by -ignore.

Based on https://github.com/jteeuwen/go-bindata/pull/150