### PR TITLE
Fix prefix argument so that it applies consistently even on windows

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -166,9 +166,7 @@ func findFiles(
 			continue
 		}
 
-		if prefix != nil && prefix.MatchString(asset.Name) {
-			asset.Name = prefix.ReplaceAllString(asset.Name, "")
-		} else if strings.HasSuffix(dir, file.Name()) {
+		if strings.HasSuffix(dir, file.Name()) {
 			// Issue 110: dir is a full path, including
 			// the file name (minus the basedir), so this
 			// is what we have to use.
@@ -180,6 +178,12 @@ func findFiles(
 			asset.Name = filepath.Join(dir, file.Name())
 		}
 
+		asset.Name = filepath.ToSlash(asset.Name)
+
+		if prefix != nil && prefix.MatchString(asset.Name) {
+			asset.Name = prefix.ReplaceAllString(asset.Name, "")
+		}
+
 		// If we have a leading slash, get rid of it.
 		if len(asset.Name) > 0 && asset.Name[0] == '/' {
 			asset.Name = asset.Name[1:]
@@ -189,8 +193,6 @@ func findFiles(
 		if len(asset.Name) == 0 {
 			return fmt.Errorf("Invalid file: %v", asset.Path)
 		}
-
-		asset.Name = filepath.ToSlash(asset.Name)
 
 		asset.Func = safeFunctionName(asset.Name, knownFuncs)
 		asset.Path, _ = filepath.Abs(asset.Path)

--- a/go-bindata/main.go
+++ b/go-bindata/main.go
@@ -111,7 +111,7 @@ func initArgs() {
 	flag.BoolVar(&cfg.NoMetadata, "nometadata", cfg.NoMetadata, "Assets will not preserve size, mode, and modtime info.")
 	flag.BoolVar(&cfg.Split, "split", cfg.NoMetadata, "Split output into several files, avoiding to have a big output file.")
 	flag.Int64Var(&cfg.ModTime, "modtime", cfg.ModTime, "Optional modification unix timestamp override for all files.")
-	flag.StringVar(&argPrefix, "prefix", "", "Optional path prefix to strip off asset names.")
+	flag.StringVar(&argPrefix, "prefix", "", "Optional path prefix regular expression to strip off asset names.")
 	flag.StringVar(&cfg.Output, "o", cfg.Output, "Optional name of the output file to be generated.")
 	flag.StringVar(&cfg.Package, "pkg", cfg.Package, "Package name to use in the generated code.")
 	flag.StringVar(&cfg.Tags, "tags", cfg.Tags, "Optional set of build tags to include.")


### PR DESCRIPTION
After updating from the old unmaintained jteeuwen version I had issues using the prefix argument:

* Having any prefix argument changes the behaviour significantly (in my case it was using full paths instead of relative paths with any prefix present). It also won't do the fix that is marked for issue #110 in this case.
* The prefix is a regexp now. This is different from the old version and not documented.
* On windows, the prefix regexp is applied to the path with backslashes in. This makes it harder to write code that's consistent across platforms.

Also slightly unrelated but very close in the code: on Windows, a leading slash won't be removed.

Here's a pull request that fixes these problems.

P.S. Thanks for maintaining this fork. I was having problems with the old version due to it not listing "DO NOT EDIT" in the correct place, so golint was confused.