### PR TITLE
Fix using absolute symlinks

### DIFF
--- a/fsscanner.go
+++ b/fsscanner.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strings"
 )
 
 // ByName implement sort.Interface for []os.FileInfo based on Name()
@@ -143,25 +142,16 @@ func (fss *FSScanner) getListFileInfo(path string) (
 }
 
 //
-// scanSymlink will,
-// (1) read the real-path from symbolic link file, and
-// (2) convert the path and real-path to relative path. Do not use
-// `filepath.Join` here, because the realPath may contain ".." and will be
-// normalized by filepath.Join.
+// scanSymlink reads the real-path from symbolic link file and converts the path
+// and real-path into a relative path.
 //
 func (fss *FSScanner) scanSymlink(path string, recursive bool) (
 	err error,
 ) {
-	// (1)
-	realPath, err := os.Readlink(path)
+	realPath, err := filepath.EvalSymlinks(path)
 	if err != nil {
 		return
 	}
-
-	// (2)
-	realPath = strings.TrimSuffix(path, filepath.Base(path)) + realPath
-
-	realPath = filepath.Clean(realPath)
 
 	fi, err := os.Lstat(realPath)
 	if err != nil {

--- a/fsscanner_test.go
+++ b/fsscanner_test.go
@@ -295,30 +295,30 @@ func TestScan(t *testing.T) {
 	}}
 
 	for _, c := range cases {
-		t.Run(c.desc, func(t *testing.T) {
+		t.Log(c.desc)
+
+		scanner.Reset()
+
+		assets := make([]Asset, 0)
+
+		for _, in := range c.inputs {
+			err = scanner.Scan(in.Path, "", in.Recursive)
+			if err != nil {
+				assert(t, c.expError, err, true)
+			}
+
+			assets = append(assets, scanner.assets...)
+
 			scanner.Reset()
+		}
 
-			assets := make([]Asset, 0)
+		assert(t, len(c.expAssets), len(assets), true)
 
-			for _, in := range c.inputs {
-				err = scanner.Scan(in.Path, "", in.Recursive)
-				if err != nil {
-					assert(t, c.expError, err, true)
-				}
-
-				assets = append(assets, scanner.assets...)
-
-				scanner.Reset()
-			}
-
-			assert(t, len(c.expAssets), len(assets), true)
-
-			for x, gotAsset := range assets {
-				assert(t, c.expAssets[x].Path, gotAsset.Path, true)
-				assert(t, c.expAssets[x].Name, gotAsset.Name, true)
-				assert(t, c.expAssets[x].Func, gotAsset.Func, true)
-			}
-		})
+		for x, gotAsset := range assets {
+			assert(t, c.expAssets[x].Path, gotAsset.Path, true)
+			assert(t, c.expAssets[x].Name, gotAsset.Name, true)
+			assert(t, c.expAssets[x].Func, gotAsset.Func, true)
+		}
 	}
 }
 


### PR DESCRIPTION
I noticed there was a bug when using absolute symlinks so I added a unit test to demaonstrate the issue and then I fixed it by using `filepath.EvalSymlinks(path)`.