### PR TITLE
Fixing issue with -debug on windows

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -7,6 +7,7 @@ package bindata
 import (
 	"fmt"
 	"io"
+	"strings"
 )
 
 // writeOneFileDebug writes the debug code file for each file (when splited file).
@@ -91,7 +92,7 @@ type asset struct {
 // A debug entry is simply a function which reads the asset from
 // the original file (e.g.: from disk).
 func writeDebugAsset(w io.Writer, c *Config, asset *Asset) error {
-	pathExpr := fmt.Sprintf("\"%s/%s\"", c.cwd, asset.Path)
+	pathExpr := strings.Replace(fmt.Sprintf("\"%s/%s\"", c.cwd, asset.Path), "\\", "/", -1)
 	if c.Dev {
 		pathExpr = fmt.Sprintf("filepath.Join(rootDir, %q)", asset.Name)
 	}

--- a/debug.go
+++ b/debug.go
@@ -7,7 +7,7 @@ package bindata
 import (
 	"fmt"
 	"io"
-	"strings"
+	"path/filepath"
 )
 
 // writeOneFileDebug writes the debug code file for each file (when splited file).
@@ -92,7 +92,7 @@ type asset struct {
 // A debug entry is simply a function which reads the asset from
 // the original file (e.g.: from disk).
 func writeDebugAsset(w io.Writer, c *Config, asset *Asset) error {
-	pathExpr := strings.Replace(fmt.Sprintf("\"%s/%s\"", c.cwd, asset.Path), "\\", "/", -1)
+	pathExpr := fmt.Sprintf("%q", filepath.Join(c.cwd, asset.Path))
 	if c.Dev {
 		pathExpr = fmt.Sprintf("filepath.Join(rootDir, %q)", asset.Name)
 	}


### PR DESCRIPTION
Added backslash cleaning for windows.
Without it, debug functions would be erroneously generated with single backslashes, causing go syntax errors.
Before:
```
func bindataDatafontsdefaultttf() (*asset, error) {
	path := "C:\Repos\GoDusk\dusk/data\fonts\default.ttf"
```

After:
```
func bindataDatafontsdefaultttf() (*asset, error) {
	path := "C:/Repos/GoDusk/dusk/data/fonts/default.ttf"
```