### PR TITLE
Allow function prefix to be specified so files can be exported

### DIFF
--- a/asset.go
+++ b/asset.go
@@ -40,7 +40,7 @@ func normalize(in string) (out string) {
 			}
 			continue
 		}
-		if r == '/' {
+		if r == '/' || r == '.' {
 			up = true
 		}
 	}

--- a/asset.go
+++ b/asset.go
@@ -51,7 +51,7 @@ func normalize(in string) (out string) {
 // newAsset will create, initialize, and return new asset based on file
 // path or real path if its symlink.
 //
-func newAsset(path, name, realPath string, fi os.FileInfo) (ast *asset) {
+func newAsset(cfg *Config, path, name, realPath string, fi os.FileInfo) (ast *asset) {
 	ast = &asset{
 		path: path,
 		name: filepath.ToSlash(name),
@@ -59,9 +59,9 @@ func newAsset(path, name, realPath string, fi os.FileInfo) (ast *asset) {
 	}
 
 	if len(realPath) == 0 {
-		ast.funcName = "bindata" + normalize(name)
+		ast.funcName = cfg.AssetPrefix + normalize(name)
 	} else {
-		ast.funcName = "bindata" + normalize(realPath)
+		ast.funcName = cfg.AssetPrefix + normalize(realPath)
 	}
 	return ast
 }

--- a/cmd/go-bindata/main.go
+++ b/cmd/go-bindata/main.go
@@ -116,6 +116,7 @@ func initArgs() {
 	flag.StringVar(&cfg.Output, "o", cfg.Output, "Optional name of the output file to be generated.")
 	flag.StringVar(&cfg.Package, "pkg", cfg.Package, "Package name to use in the generated code.")
 	flag.StringVar(&cfg.Tags, "tags", cfg.Tags, "Optional set of build tags to include.")
+	flag.StringVar(&cfg.AssetPrefix, "assetprefix", cfg.AssetPrefix, "Prefix for the name of the asset function. Begin with a capital letter to export them")
 	flag.UintVar(&cfg.Mode, "mode", cfg.Mode, "Optional file mode override for all files.")
 	flag.Var((*AppendSliceValue)(&argIgnore), "ignore", "Regex pattern to ignore")
 	flag.Var((*AppendSliceValue)(&argInclude), "include", "Regex pattern to include")

--- a/config.go
+++ b/config.go
@@ -18,6 +18,9 @@ const (
 
 	// DefOutputName define default generated file name.
 	DefOutputName = "bindata.go"
+
+	// Default prefix for asset functions
+	DefAssetPrefixName = "bindata"
 )
 
 // List of errors.
@@ -50,6 +53,10 @@ type Config struct {
 	// working directory and the current directory in case of having true
 	// to `Split` config.
 	Output string
+
+	// This defines the string that is prepended to asset functions.
+	// This can be used to export these functions directly. 
+	AssetPrefix string
 
 	// Prefix defines a regular expression which should used to strip
 	// substrings from all file names when generating the keys in the table of
@@ -176,6 +183,7 @@ func NewConfig() *Config {
 	c := new(Config)
 	c.Package = DefPackageName
 	c.Output = DefOutputName
+	c.AssetPrefix = DefAssetPrefixName
 	c.Ignore = make([]*regexp.Regexp, 0)
 	c.Include = make([]*regexp.Regexp, 0)
 	return c

--- a/debug.go
+++ b/debug.go
@@ -99,6 +99,14 @@ func writeDebugAsset(w io.Writer, c *Config, ast *asset) error {
 	}
 
 	_, err := fmt.Fprintf(w, `// %s reads file data from disk. It returns an error on failure.
+func %sBytes() ([]byte, error) {
+	asset, err := %s()
+	if asset == nil {
+		return nil, err
+	}
+	return asset.bytes, err
+}
+
 func %s() (*asset, error) {
 	path := %s
 	name := %q
@@ -116,6 +124,6 @@ func %s() (*asset, error) {
 	return a, err
 }
 
-`, ast.funcName, ast.funcName, pathExpr, ast.name)
+`, ast.funcName, ast.funcName, ast.funcName, ast.funcName, pathExpr, ast.name)
 	return err
 }

--- a/fsscanner.go
+++ b/fsscanner.go
@@ -93,7 +93,7 @@ func (fss *fsScanner) cleanPrefix(path string) string {
 func (fss *fsScanner) addAsset(path, realPath string, fi os.FileInfo) {
 	name := fss.cleanPrefix(path)
 
-	asset := newAsset(path, name, realPath, fi)
+	asset := newAsset(fss.cfg, path, name, realPath, fi)
 
 	// Check if the asset's name is already exist.
 	_, ok := fss.assets[name]

--- a/fsscanner_test.go
+++ b/fsscanner_test.go
@@ -19,6 +19,7 @@ func TestScan(t *testing.T) {
 
 	cfg := &Config{
 		cwd: cwd,
+		AssetPrefix: "bindata",
 	}
 
 	scanner := newFSScanner(cfg)
@@ -80,7 +81,7 @@ func TestScan(t *testing.T) {
 			"testdata/in/a/test.asset": {
 				path:     "testdata/in/a/test.asset",
 				name:     "testdata/in/a/test.asset",
-				funcName: "bindataTestdataInATestasset",
+				funcName: "bindataTestdataInATestAsset",
 			},
 		},
 	}, {
@@ -402,6 +403,7 @@ func TestScanAbsoluteSymlink(t *testing.T) {
 
 	cfg := &Config{
 		cwd: cwd,
+		AssetPrefix: "bindata",
 	}
 
 	tmpDir, err := ioutil.TempDir("", "go-bindata-test")


### PR DESCRIPTION
While the "filesystem" functionality is helpful in many circumstances, it seems there are also times when you want to just grab the data directly using a function rather than using a string.  This static binding seems much more go-ish as well.  For instance, I can make a `data` package which has my data in it.  Then, from other packages, I can reference `data.FileMyFilepng()` which will be statically checked at compile time.  When doing it by strings you have both (a) the extra lookup time, and (b) the possibility that someone will type the wrong string and you won't catch it at compile time. 

By adding an -assetpath flag, if someone wants, they can cause the files to be exported for general package use.